### PR TITLE
chore: improve the docker image creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,13 @@ version = "0.1.5"
 edition = "2024"
 publish = false
 
+[profile.release]
+opt-level = 'z'     # Optimize for size
+lto = true          # Enable link-time optimization
+codegen-units = 1   # Reduce number of codegen units to increase optimizations
+panic = 'abort'     # Abort on panic
+strip = true        # Strip symbols from binary*
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM rust:1.86.0-slim-bookworm AS builder
 RUN apt-get update && apt-get install -y --no-install-recommends cmake
 WORKDIR /usr/src/manta-ws
 COPY . .
-RUN cargo build --release
+RUN cargo build --release --jobs $(nproc)
 
 FROM debian:bookworm-slim
 COPY --from=builder /usr/src/manta-ws/target/release/manta-ws /usr/local/bin/manta-ws

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85.1 AS builder
+FROM rust:1.86.0-slim-bookworm AS builder
 # Install cmake for building the `librdkafka` crate statically
 RUN apt-get update && apt-get install -y cmake
 WORKDIR /usr/src/manta-ws

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.86.0-slim-bookworm AS builder
 # Install cmake for building the `librdkafka` crate statically
-RUN apt-get update && apt-get install -y cmake
+RUN apt-get update && apt-get install -y --no-install-recommends cmake
 WORKDIR /usr/src/manta-ws
 COPY . .
 RUN cargo install --jobs $(nproc) --path .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85.1 as builder
+FROM rust:1.85.1 AS builder
 # Install cmake for building the `librdkafka` crate statically
 RUN apt-get update && apt-get install -y cmake
 WORKDIR /usr/src/manta-ws

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN cargo install --jobs $(nproc) --path .
 
 FROM debian:bookworm-slim
 COPY --from=builder /usr/local/cargo/bin/manta-ws /usr/local/bin/manta-ws
-CMD ["manta-ws"]
+CMD ["/usr/local/bin/manta-ws"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM rust:1.86.0-slim-bookworm AS builder
 RUN apt-get update && apt-get install -y --no-install-recommends cmake
 WORKDIR /usr/src/manta-ws
 COPY . .
-RUN cargo install --jobs $(nproc) --path .
+RUN cargo build --release
 
 FROM debian:bookworm-slim
-COPY --from=builder /usr/local/cargo/bin/manta-ws /usr/local/bin/manta-ws
+COPY --from=builder /usr/src/manta-ws/target/release/manta-ws /usr/local/bin/manta-ws
 CMD ["/usr/local/bin/manta-ws"]


### PR DESCRIPTION
# Improve the docker image creation

The size of the final docker image is `83.3MB`.

The size of the binary is `8.1M`.

## Feature

### Rust

* add optimizations for building release
  > see [stackoverflow](https://stackoverflow.com/a/54842093)

## Chore

### Docker

* change the way to build the binary
* add flag to apt
* upgrade the builder
* use the complete path
* as casing
