### PR TITLE
chore: Release manta-ws version 0.1.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manta-ws"
 description = "HTTP server for Mesa"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2024"
 publish = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ strip = true        # Strip symbols from binary*
 # csm-rs = { git = "https://github.com/eth-cscs/csm-rs", branch="feature/power-status" } # Only for development purposes
 manta-backend-dispatcher = "0.1.79"
 csm-rs = "0.5.0-beta.11"
-ochami-rs = "0.1.78"
+ochami-rs = "0.6.4"
 
 anyhow = { version = "1.0.98", default-features = false }
 directories = "6.0.0" # XDG Base Directory Specification


### PR DESCRIPTION
- **chore: use ochami-rs version 0.6.4**
- **chore: Release manta-ws version 0.1.16**
